### PR TITLE
Fix activity references counting in SessionVerificationService

### DIFF
--- a/sdk-core/src/main/java/com/gigya/android/sdk/session/SessionVerificationService.java
+++ b/sdk-core/src/main/java/com/gigya/android/sdk/session/SessionVerificationService.java
@@ -88,16 +88,17 @@ public class SessionVerificationService implements ISessionVerificationService {
         _context.registerActivityLifecycleCallbacks(new Application.ActivityLifecycleCallbacks() {
 
             private int activityReferences = 0;
+            private int startedActivityReferences = 0;
             private boolean isActivityChangingConfigurations = false;
 
             @Override
             public void onActivityCreated(Activity activity, Bundle bundle) {
-                // Stub.
+                ++activityReferences;
             }
 
             @Override
             public void onActivityStarted(Activity activity) {
-                if (++activityReferences == 1 && !isActivityChangingConfigurations) {
+                if (++startedActivityReferences == 1 && !isActivityChangingConfigurations) {
                     // App enters foreground
 
                     _sessionService.refreshSessionExpiration();
@@ -125,7 +126,7 @@ public class SessionVerificationService implements ISessionVerificationService {
             @Override
             public void onActivityStopped(Activity activity) {
                 isActivityChangingConfigurations = activity.isChangingConfigurations();
-                if (--activityReferences == 0 && !isActivityChangingConfigurations) {
+                if (--startedActivityReferences == 0 && !isActivityChangingConfigurations) {
                     // App enters background
                     GigyaLogger.info(LOG_TAG, "Application lifecycle - Background stopped first activity");
                     stop();


### PR DESCRIPTION
`SessionVerificationService` does not work properly and is always disabled, because its activity references counter is incremented in `onActivityStarted()`, but is decremented both in `onActivityStopped()` and `onActivityDestroyed()`, so its value quickly becomes negative and keeps decreasing. The service is only started when the counter value is `1`, but this value is never reached a second time.

This PR fixes the issue by creating two separate counters: one which keeps track of **created** activities, and another one which keeps track of **started** activities, and increment/decrement their values at the appropriate time.