### PR TITLE
Set webview debugging if gigya logger is in debug mode similar to iOS

### DIFF
--- a/sdk-core/src/main/java/com/gigya/android/sdk/ui/plugin/GigyaWebBridge.java
+++ b/sdk-core/src/main/java/com/gigya/android/sdk/ui/plugin/GigyaWebBridge.java
@@ -23,6 +23,7 @@ import android.content.Context;
 import android.content.pm.ApplicationInfo;
 import android.net.Uri;
 import android.util.Base64;
+import android.util.Log;
 import android.view.View;
 import android.webkit.JavascriptInterface;
 import android.webkit.ValueCallback;
@@ -496,7 +497,10 @@ public class GigyaWebBridge<A extends GigyaAccount> implements IGigyaWebBridge<A
             @Nullable final View progressView) {
         if ((_context.getApplicationInfo().flags & ApplicationInfo.FLAG_DEBUGGABLE) != 0 && GigyaLogger.isDebug()) {
             WebView.setWebContentsDebuggingEnabled(true);
-        } 
+                Log.i("DebugCheck", "App is in DEBUG mode");
+        } else {
+                Log.i("DebugCheck", "App is in RELEASE mode");
+        }
         if (android.os.Build.VERSION.SDK_INT < 17) {
             GigyaLogger.error(LOG_TAG, "WebBridge invocation is only available for Android >= 17");
             return;

--- a/sdk-core/src/main/java/com/gigya/android/sdk/ui/plugin/GigyaWebBridge.java
+++ b/sdk-core/src/main/java/com/gigya/android/sdk/ui/plugin/GigyaWebBridge.java
@@ -20,6 +20,7 @@ import static com.gigya.android.sdk.ui.plugin.PluginEventDef.SUBMIT;
 
 import android.annotation.SuppressLint;
 import android.content.Context;
+import android.content.pm.ApplicationInfo;
 import android.net.Uri;
 import android.util.Base64;
 import android.view.View;
@@ -493,7 +494,9 @@ public class GigyaWebBridge<A extends GigyaAccount> implements IGigyaWebBridge<A
             @NonNull final WebView webView,
             @NonNull final GigyaPluginCallback<A> pluginCallback,
             @Nullable final View progressView) {
-
+        if ((_context.getApplicationInfo().flags & ApplicationInfo.FLAG_DEBUGGABLE) != 0 && GigyaLogger.isDebug()) {
+            WebView.setWebContentsDebuggingEnabled(true);
+        } 
         if (android.os.Build.VERSION.SDK_INT < 17) {
             GigyaLogger.error(LOG_TAG, "WebBridge invocation is only available for Android >= 17");
             return;

--- a/sdk-core/src/main/java/com/gigya/android/sdk/ui/plugin/GigyaWebBridge.java
+++ b/sdk-core/src/main/java/com/gigya/android/sdk/ui/plugin/GigyaWebBridge.java
@@ -497,9 +497,6 @@ public class GigyaWebBridge<A extends GigyaAccount> implements IGigyaWebBridge<A
             @Nullable final View progressView) {
         if ((_context.getApplicationInfo().flags & ApplicationInfo.FLAG_DEBUGGABLE) != 0 && GigyaLogger.isDebug()) {
             WebView.setWebContentsDebuggingEnabled(true);
-                Log.i("DebugCheck", "App is in DEBUG mode");
-        } else {
-                Log.i("DebugCheck", "App is in RELEASE mode");
         }
         if (android.os.Build.VERSION.SDK_INT < 17) {
             GigyaLogger.error(LOG_TAG, "WebBridge invocation is only available for Android >= 17");


### PR DESCRIPTION
In [iOS](https://github.com/SAP/gigya-swift-sdk/blame/1ace6fd17dbd04478da429e112f04a0109883565/GigyaSwift/Global/Plugins/GigyaWebBridge.swift#L88), there is implementation to automatically set the `isInspectable` value of the `WKWebView` as `true` of the NSS WebView if the build is in `DEBUG` mode and if `GigyaLogger.isDebug()` returns `true`. This is is not the case for the Android SDK. This PR updates the Android implementation to match iOS so the same solution can be used for both platforms on the gigya-flutter-plugin.

We are using the gigya-flutter-plugin and I have created a [PR](https://github.com/SAP/gigya-flutter-plugin/pull/85) to make use of this functionality as we are unable to access the WEBVIEW context when using the Appium Flutter driver to build some integration tests. But in the gigya-flutter-plugin the implementations on iOS and Android need to be different as setting the GigyaLogger to Debug mode is not sufficient to enable debugging of the WebView.