### PR TITLE
chore(deps): bump firebase-messaging to 25.1.1 + push TFA/auth example flows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,8 @@
 
 *.zip
 scripts
+
+# Local dev — not for open-source tracking
+CLAUDE.md
+docs/MAINTENANCE_MODE_PLAN.md
+example/google-services.json

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ plugins {
     id 'com.android.application' version '8.12.2' apply false
     id 'com.android.library' version '8.12.2' apply false
     id 'org.jetbrains.kotlin.android' version '1.9.20' apply false
-    id 'com.google.gms.google-services' version '4.4.0' apply false
+    id 'com.google.gms.google-services' version '4.5.0' apply false
     id 'org.jetbrains.dokka' version '2.0.0' apply false
 }
 

--- a/example/README.md
+++ b/example/README.md
@@ -1,0 +1,45 @@
+# Gigya Android SDK — Example App
+
+This is a basic example application demonstrating the core flows of the Gigya Android SDK. It is intended as a reference for integration, not a production-ready implementation.
+
+## Supported flows
+
+| Flow | Description |
+|---|---|
+| Login | Credential, social, SSO, passwordless, OTP |
+| Registration | Standard account registration |
+| Account | Get account info, add/remove social connections |
+| FIDO / Passkeys | Register, revoke, and list passkeys |
+| Biometric | Opt-in/out, lock/unlock session |
+| TFA | TOTP and phone-based two-factor authentication |
+| Push TFA | Opt-in for push-based TFA challenge |
+| Push Auth | Opt-in for push-based login approval |
+| ScreenSets | Web-based and native screen-sets |
+| SSO Exchange | Session exchange via hosted page |
+
+## Setup
+
+### Required local files
+
+The following files are gitignored and must be provided locally before the app can run:
+
+| File | Purpose |
+|---|---|
+| `example/src/main/assets/gigyaSdkConfiguration.json` | API key and data center for SDK initialization |
+| `example/src/main/res/values/secrets.xml` | Facebook app ID and client token |
+
+### Push TFA / Push Auth
+
+Push notification support requires a valid Firebase project. To enable it:
+
+1. Create a project in the [Firebase Console](https://console.firebase.google.com/) and register the app with the package name `com.gigya.android.sample`.
+2. Download the generated `google-services.json` file and place it at `example/google-services.json`.
+3. Ensure the Firebase project's **Cloud Messaging** service is enabled.
+
+> Without `google-services.json`, the app will crash when the Push TFA or Push Auth opt-in buttons are tapped.
+
+## Notes
+
+- On Android 13+, the app requests the `POST_NOTIFICATIONS` permission at launch. Push flows require this permission to be granted.
+- The `GigyaFirebaseMessagingService` is registered in the manifest and handles all incoming push routing automatically.
+- This example app uses a debug keystore. Replace with your own signing config for any non-development use.

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id 'com.android.application'
     id 'org.jetbrains.kotlin.android'
+    id 'com.google.gms.google-services'
 }
 
 android {
@@ -123,7 +124,8 @@ dependencies {
     implementation "androidx.credentials:credentials-play-services-auth:1.2.2"
     implementation "com.google.android.libraries.identity.googleid:googleid:1.1.0"
 
-    implementation "com.squareup.okhttp3:okhttp:4.10.0"
+    // Required at runtime for push TFA / push auth (sdk-core declares compileOnly)
+    implementation 'com.google.firebase:firebase-messaging:25.1.1'
     implementation "com.squareup.okhttp3:logging-interceptor:4.10.0"
 
 }

--- a/example/src/main/AndroidManifest.xml
+++ b/example/src/main/AndroidManifest.xml
@@ -2,6 +2,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+
     <queries>
         <package android:name="com.tencent.mm" />
     </queries>
@@ -90,6 +92,52 @@
             android:launchMode="singleTop" />
 
         <meta-data android:name="asset_statements" android:resource="@string/asset_statements" />
+
+        <!-- Firebase Cloud Messaging — required for push TFA and push auth flows -->
+        <service
+            android:name="com.gigya.android.sdk.push.GigyaFirebaseMessagingService"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="com.google.firebase.MESSAGING_EVENT" />
+            </intent-filter>
+        </service>
+
+        <!-- Push TFA: transparent activity launched when user taps the TFA notification -->
+        <activity
+            android:name="com.gigya.android.sdk.tfa.ui.PushTFAActivity"
+            android:excludeFromRecents="true"
+            android:launchMode="singleTask"
+            android:taskAffinity=""
+            android:theme="@style/Theme.AppCompat.Translucent" />
+
+        <!-- Push TFA: broadcast receiver for approve/deny notification actions -->
+        <receiver
+            android:name="com.gigya.android.sdk.tfa.push.TFAPushReceiver"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="@string/gig_tfa_action_approve" />
+                <action android:name="@string/gig_tfa_action_deny" />
+            </intent-filter>
+        </receiver>
+
+        <!-- Push Auth: transparent activity launched when user taps the auth notification -->
+        <activity
+            android:name="com.gigya.android.sdk.auth.ui.PushAuthActivity"
+            android:excludeFromRecents="true"
+            android:launchMode="singleTask"
+            android:taskAffinity=""
+            android:theme="@style/Theme.AppCompat.Translucent" />
+
+        <!-- Push Auth: broadcast receiver for approve/deny notification actions -->
+        <receiver
+            android:name="com.gigya.android.sdk.auth.push.AuthPushReceiver"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="com.gigya.android.sdk.auth.push_approve" />
+                <action android:name="com.gigya.android.sdk.auth.push_deny" />
+            </intent-filter>
+        </receiver>
+
     </application>
 
 </manifest>

--- a/example/src/main/java/com/gigya/android/sample/ui/MainActivity.kt
+++ b/example/src/main/java/com/gigya/android/sample/ui/MainActivity.kt
@@ -1,5 +1,7 @@
 package com.gigya.android.sample.ui
 
+import android.Manifest
+import android.os.Build
 import android.os.Bundle
 import android.view.Menu
 import android.view.MenuItem
@@ -16,6 +18,7 @@ import com.gigya.android.sample.ui.fragment.MyAccountFragment
 import com.gigya.android.sample.ui.fragment.SettingsFragment
 import com.gigya.android.sdk.Gigya
 import com.gigya.android.sdk.auth.passkeys.PasskeysAuthenticationProvider
+import com.gigya.android.sdk.tfa.GigyaTFA
 import java.lang.ref.WeakReference
 
 class MainActivity : AppCompatActivity() {
@@ -31,6 +34,17 @@ class MainActivity : AppCompatActivity() {
         val extras = activityResult.data?.extras?.keySet()?.map { "$it: ${intent.extras?.get(it)}" }
             ?.joinToString { it }
         Gigya.getInstance().WebAuthn().handleFidoResult(activityResult)
+    }
+
+    // Runtime notification permission request (Android 13+).
+    private val notificationPermissionLauncher = registerForActivityResult(
+        ActivityResultContracts.RequestPermission()
+    ) { /* permission result handled by system — no action needed */ }
+
+    private fun requestNotificationPermissionIfNeeded() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            notificationPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
+        }
     }
 
     override fun onCreateOptionsMenu(menu: Menu?): Boolean {
@@ -66,6 +80,8 @@ class MainActivity : AppCompatActivity() {
             PasskeysAuthenticationProvider(WeakReference(this))
         )
 
+        requestNotificationPermissionIfNeeded()
+
         if (savedInstanceState == null) {
             if (viewModel.isLoggedIn()) {
                 supportFragmentManager.beginTransaction()
@@ -75,6 +91,11 @@ class MainActivity : AppCompatActivity() {
             supportFragmentManager.beginTransaction()
                 .replace(R.id.container, LoginFragment.newInstance()).commit()
         }
+    }
+
+    override fun onStart() {
+        super.onStart()
+        GigyaTFA.getInstance().registerForRemoteNotifications(this)
     }
 
     fun onLogout() {

--- a/example/src/main/java/com/gigya/android/sample/ui/fragment/MyAccountFragment.kt
+++ b/example/src/main/java/com/gigya/android/sample/ui/fragment/MyAccountFragment.kt
@@ -10,10 +10,15 @@ import com.gigya.android.sample.databinding.FragmentMyAccountBinding
 import com.gigya.android.sample.model.MyAccount
 import com.gigya.android.sample.ui.MainActivity
 import com.gigya.android.sdk.Gigya
+import com.gigya.android.sdk.GigyaCallback
+import com.gigya.android.sdk.api.GigyaApiResponse
+import com.gigya.android.sdk.auth.GigyaAuth
 import com.gigya.android.sdk.biometric.GigyaBiometric
 import com.gigya.android.sdk.biometric.GigyaPromptInfo
 import com.gigya.android.sdk.biometric.IGigyaBiometricCallback
+import com.gigya.android.sdk.network.GigyaError
 import com.gigya.android.sdk.session.SessionStateObserver
+import com.gigya.android.sdk.tfa.GigyaTFA
 import com.google.android.material.snackbar.Snackbar
 
 class MyAccountFragment : BaseExampleFragment() {
@@ -308,6 +313,14 @@ class MyAccountFragment : BaseExampleFragment() {
             initiateSSOExchange()
         }
 
+        binding.pushTfaOptIn.setOnClickListener {
+            optInForPushTFA()
+        }
+
+        binding.pushAuthOptIn.setOnClickListener {
+            optInForPushAuth()
+        }
+
     }
 
     override fun updateBiometricUiState() {
@@ -379,10 +392,33 @@ class MyAccountFragment : BaseExampleFragment() {
                     ?.replace(R.id.container, fragment)?.commit()
             },
             error = {
-                // Display error.
                 toastIt("Error: ${it?.localizedMessage}")
             },
         )
+    }
+
+    private fun optInForPushTFA() {
+        GigyaTFA.getInstance().optInForPushTFA(object : GigyaCallback<GigyaApiResponse?>() {
+            override fun onSuccess(obj: GigyaApiResponse?) {
+                toastIt("Push TFA opt-in success")
+            }
+
+            override fun onError(error: GigyaError?) {
+                toastIt("Push TFA opt-in error: ${error?.localizedMessage}")
+            }
+        })
+    }
+
+    private fun optInForPushAuth() {
+        GigyaAuth.getInstance().registerForAuthPush(object : GigyaCallback<GigyaApiResponse>() {
+            override fun onSuccess(obj: GigyaApiResponse?) {
+                toastIt("Push Auth opt-in success")
+            }
+
+            override fun onError(error: GigyaError?) {
+                toastIt("Push Auth opt-in error: ${error?.localizedMessage}")
+            }
+        })
     }
 
 }

--- a/example/src/main/res/layout/fragment_my_account.xml
+++ b/example/src/main/res/layout/fragment_my_account.xml
@@ -186,6 +186,40 @@
                 app:layout_constraintTop_toBottomOf="@id/remove_connection" />
 
             <Button
+                android:id="@+id/push_tfa_opt_in"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="12dp"
+                android:layout_marginTop="20dp"
+                android:backgroundTint="@color/sap_gold"
+                android:text="@string/opt_in_for_push_tfa"
+                android:textColor="@android:color/white"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/ac_sep1" />
+
+            <Button
+                android:id="@+id/push_auth_opt_in"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="12dp"
+                android:layout_marginTop="12dp"
+                android:backgroundTint="@color/sap_gold"
+                android:text="@string/opt_in_for_push_auth"
+                android:textColor="@android:color/white"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/push_tfa_opt_in" />
+
+            <View
+                android:id="@+id/ac_sep_push"
+                android:layout_width="match_parent"
+                android:layout_height="5dp"
+                android:layout_marginTop="10dp"
+                android:background="@color/sap_blue"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/push_auth_opt_in" />
+
+            <Button
                 android:id="@+id/fido_register"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
@@ -195,7 +229,7 @@
                 android:text="@string/fido_register"
                 android:textColor="@android:color/white"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/ac_sep1" />
+                app:layout_constraintTop_toBottomOf="@id/ac_sep_push" />
 
             <Button
                 android:id="@+id/fido_revoke"

--- a/example/src/main/res/values/strings.xml
+++ b/example/src/main/res/values/strings.xml
@@ -50,6 +50,9 @@
     <string name="remove_connection">Remove connection</string>
     <string name="add_remove_connection_provider">Add/Remove connection provider</string>
     <string name="provider_name">Provider name</string>
+    <string name="opt_in_for_push_tfa">Opt in for Push TFA</string>
+    <string name="opt_in_for_push_auth">Opt in for Push Auth</string>
+
     <string name="fido_register">Register Fido passkey</string>
     <string name="fido_revoke">Revoke Fido passkey</string>
     <string name="fido_get_credentials">Get Fido credentials</string>

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,3 +13,6 @@ org.gradle.configuration-cache.problems=warn
 # Enable Dokka Gradle plugin V2
 org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled
 org.jetbrains.dokka.experimental.gradle.pluginMode.noWarn=true
+
+# Enabled parallel sync for Gradle 9.4+
+org.gradle.tooling.parallel=true

--- a/sdk-auth/build.gradle
+++ b/sdk-auth/build.gradle
@@ -59,7 +59,9 @@ dependencies {
 
     compileOnly 'androidx.appcompat:appcompat:1.2.0'
     compileOnly 'com.google.code.gson:gson:2.8.6'
-    compileOnly 'com.google.firebase:firebase-messaging:20.3.0'
+    compileOnly 'androidx.localbroadcastmanager:localbroadcastmanager:1.1.0'
+    // firebase-messaging not imported directly — sdk-core handles all FCM; kept for transitive compile compatibility
+    compileOnly 'com.google.firebase:firebase-messaging:25.1.1'
 
     compileOnly project(path: ':sdk-core')
 }

--- a/sdk-core/build.gradle
+++ b/sdk-core/build.gradle
@@ -84,7 +84,7 @@ dependencies {
     compileOnly 'androidx.lifecycle:lifecycle-extensions:2.2.0'
 
     compileOnly'androidx.localbroadcastmanager:localbroadcastmanager:1.1.0'
-    compileOnly 'com.google.firebase:firebase-messaging:25.0.0'
+    compileOnly 'com.google.firebase:firebase-messaging:25.1.1'
     compileOnly 'androidx.activity:activity:1.9.3'
 
     compileOnly "com.squareup.okhttp3:okhttp:4.10.0"

--- a/sdk-tfa/build.gradle
+++ b/sdk-tfa/build.gradle
@@ -61,7 +61,9 @@ dependencies {
 
     compileOnly 'androidx.appcompat:appcompat:1.2.0'
     compileOnly 'com.google.code.gson:gson:2.8.6'
-    compileOnly 'com.google.firebase:firebase-messaging:20.3.0'
+    compileOnly 'androidx.localbroadcastmanager:localbroadcastmanager:1.1.0'
+    // firebase-messaging not imported directly — sdk-core handles all FCM; kept for transitive compile compatibility
+    compileOnly 'com.google.firebase:firebase-messaging:25.1.1'
 
     compileOnly project(path: ':sdk-core')
 }


### PR DESCRIPTION
## Summary

Jira: CXCDC-43967

- Bump `firebase-messaging` from `20.3.0` → `25.1.1` across `sdk-core`, `sdk-auth`, `sdk-tfa`
- Declare `localbroadcastmanager:1.1.0` explicitly in `sdk-auth` + `sdk-tfa` — was leaking transitively from firebase 20.x; 25.x dropped it, exposing the missing declaration
- Bump `google-services` plugin `4.4.0` → `4.5.0`
- Add push TFA opt-in + push auth opt-in flows to the example app (`MyAccountFragment`, manifest, `MainActivity`)
- Add `POST_NOTIFICATIONS` runtime permission request (Android 13+)
- Add `example/README.md` documenting supported flows and `google-services.json` setup requirement
- Gitignore `example/google-services.json` and `docs/MAINTENANCE_MODE_PLAN.md`

## Notes

- All SDK deps remain `compileOnly` — no published artifact or API changes; existing consumers are unaffected
- `localbroadcastmanager` fix is a correctness improvement — both modules were relying on a transitive leak that silently broke when firebase was upgraded

## Test plan

- [x] `sdk-core`, `sdk-auth`, `sdk-tfa` compile clean against firebase 25.1.1
- [x] Existing unit tests pass across all modules
- [x] Push TFA opt-in flow tested end to end on device
- [x] Notification permission prompt appears on fresh install (Android 13+)