### PR TITLE
chore(sdk-core): remove unused lifecycle-extensions dependency

### DIFF
--- a/sdk-core/build.gradle
+++ b/sdk-core/build.gradle
@@ -81,7 +81,6 @@ dependencies {
 
     compileOnly 'androidx.appcompat:appcompat:1.7.1'
     compileOnly 'com.google.code.gson:gson:2.8.6'
-    compileOnly 'androidx.lifecycle:lifecycle-extensions:2.2.0'
 
     compileOnly'androidx.localbroadcastmanager:localbroadcastmanager:1.1.0'
     compileOnly 'com.google.firebase:firebase-messaging:25.1.1'


### PR DESCRIPTION
## Summary
- Removes the `compileOnly 'androidx.lifecycle:lifecycle-extensions:2.2.0'` declaration from `sdk-core/build.gradle`
- Audit confirmed no source file in `sdk-core` imports any `androidx.lifecycle` class — the dependency was declared but never consumed
- `sdk-nss` already had the same line commented out
- No replacement artifacts needed

## Test plan
- [ ] `./gradlew :sdk-core:assembleRelease` passes clean